### PR TITLE
fix missing escape-string-regexp dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [this project's specs](https://github.com/ghempton/mocha-lazy-bdd/blob/maste
 
 ```
 npm install --save-dev mocha-lazy-bdd
-mocha -u lazy-bdd
+mocha -u mocha-lazy-bdd
 ```
 
 Or in a browser environment: install `mocha-lazy` via bower and then include the distribution before mocha has been setup.

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "chai": "^1.10.0",
     "mocha": "^2.1.0",
     "webpack": "^1.4.15"
+  },
+  "dependencies": {
+    "escape-string-regexp": "^1.0.3"
   }
 }


### PR DESCRIPTION
This is likely a fix for #1 as well (as I saw the same error using a different toolchain), but also simply running `node run-tests.js` resulted in `Error: Cannot find module 'escape-string-regexp'`.

Also included is a fix to your README, which resolves another cause of the `Error: invalid interface "lazy-bdd"` error.