### PR TITLE
Lifting the upper bound on the supported Mocha version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "license": "ISC",
   "peerDependencies": {
-    "mocha": ">=2.4.0 <3.1.0"
+    "mocha": ">=2.4.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",
-    "mocha": ">=2.4.0 <3.1.0",
+    "mocha": ">=2.4.0",
     "webpack": "^1.4.15"
   },
   "dependencies": {


### PR DESCRIPTION
Tests pass. Seems to work alright. The current version of Mocha exceeds the version declared in this project as the maximum supported version.