### PR TITLE
Add useCache flag to lazy and subject

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = Mocha.interfaces['lazy-bdd'] = function(suite){
      * Define a lazy property.
      */
 
-    context.lazy = function(name, fn) {
+    context.lazy = function(name, fn, { useCache = true } = {}) {
       var key = name,
           prototype = suites[0].ctx;
       Object.defineProperty(prototype, name, {
@@ -61,7 +61,7 @@ module.exports = Mocha.interfaces['lazy-bdd'] = function(suite){
             insideTest = true;
             return this.currentTest.ctx[name];
           }
-          if(key in cache) {
+          if(useCache && key in cache) {
             insideTest = false;
             return cache[key];
           }
@@ -84,12 +84,13 @@ module.exports = Mocha.interfaces['lazy-bdd'] = function(suite){
      * Alias for `lazy` and provides 'subject' name as default.
      */
 
-    context.subject = function(name, fn) {
-      if(arguments.length === 1) {
+    context.subject = function(name, fn, opts) {
+      if(typeof name === 'function') {
+        opts = fn;
         fn = name;
         name = 'subject';
       }
-      context.lazy.call(this, name, fn);
+      context.lazy.call(this, name, fn, opts);
     };
 
 

--- a/spec.js
+++ b/spec.js
@@ -44,6 +44,19 @@ describe('mocha-lazy-bdd', function() {
       }.bind(this);
       expect(setValue).to.throw(Error);
     });
+
+    context('without caching', function() {
+      lazy('value', function() {
+        hitCount++;
+        return 'i am not cached';
+      }, { useCache: false });
+
+      it('does not cache the result', function() {
+        expect(this.value).to.eq('i am not cached');
+        expect(this.value).to.eq('i am not cached');
+        expect(hitCount).to.eq(2);
+      });
+    })
     
     context('inside a nested context', function() {
 
@@ -132,8 +145,13 @@ describe('mocha-lazy-bdd', function() {
   });
 
   describe('subject', function() {
+    var hitCount;
+    beforeEach(function() {
+      hitCount = 0;
+    });
 
     subject(function() {
+      hitCount++
       return 'laziness';
     });
 
@@ -149,6 +167,24 @@ describe('mocha-lazy-bdd', function() {
       expect(this.namedSubject).to.eq('haz name');
     });
 
+    it('caches the result', function() {
+      expect(this.subject).to.eq('laziness');
+      expect(this.subject).to.eq('laziness');
+      expect(hitCount).to.eq(1);
+    });
+
+    context('without caching', function() {
+      subject(function() {
+        hitCount++;
+        return 'uncached laziness';
+      }, { useCache: false });
+
+      it('does not cache the result', function() {
+        expect(this.subject).to.eq('uncached laziness');
+        expect(this.subject).to.eq('uncached laziness');
+        expect(hitCount).to.eq(2);
+      });
+    })
   });
 
   describe('beforeEach', function() {


### PR DESCRIPTION
This adds an options object that can be passed to the lazy method. It will also pass through the subject function. The ultimate purpose of this is to allow re-evaluation of the subject in cases where that is deemed necessary.